### PR TITLE
Make it possible to import tile_pages

### DIFF
--- a/pdfstitcher.py
+++ b/pdfstitcher.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 # PDFStitcher is a utility to work with PDF sewing patterns.
 # Copyright (C) 2021 Charlotte Curtis
 #

--- a/tile_pages.py
+++ b/tile_pages.py
@@ -22,6 +22,7 @@ import sys
 import math
 import copy
 import utils
+from gettext import gettext as _
 
 class PageTiler():
     def __init__(self,in_doc = None):

--- a/utils.py
+++ b/utils.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from gettext import gettext as _
+
 def txt_to_float(txt):
     if txt is None or not txt.strip():
         return 0


### PR DESCRIPTION
I am importing the `tile_pages` and `utils` modules from PDFStitcher in my own project, but get a NameError Exception about the gettext localization indicator '_' being undefined.
Explicitly importing gettext in both files (`from gettext import gettext as _`) fixes the problem.