### PR TITLE
Improve `get_layer_names()`

### DIFF
--- a/layerfilter.py
+++ b/layerfilter.py
@@ -400,5 +400,5 @@ class LayerFilter:
             traceback.print_exc()
             #print("couldn't open stream ", sys.exc_info()[0] )
             print("couldn't open stream")
-            #ignore - probably not a content stream. Print an error when debugging
-            # ignore = 1
+            # ignore - probably not a content stream. Print an error when debugging
+            #ignore = 1

--- a/layerfilter.py
+++ b/layerfilter.py
@@ -68,25 +68,13 @@ class LayerFilter:
                 LayerFilter._search_names(ordered_names, o, depth=depth+1)
     
     @staticmethod
-    def _has_nested_key(obj, keys):
-        ok = True
-        to_check = obj
-        for key in keys:
-            if key in to_check.keys():
-                to_check = to_check[key]
-            else:
-                ok = False
-                break
-        return ok
-    
-    @staticmethod
     def get_layer_names(doc):
         # reads through the root to parse out the layers present in the file
         if '/OCProperties' not in doc.Root.keys():
             return None
         names = [str(oc.Name) for oc in doc.Root.OCProperties.OCGs]
         ordered_names = []
-        if LayerFilter._has_nested_key(doc.Root.OCProperties, ['/D', '/Order']):
+        if '/D' in doc.Root.OCProperties.keys():
             LayerFilter._search_names(ordered_names, doc.Root.OCProperties.D.Order)
         for n in names:
             real_n = LayerFilter._fix_utf16(n)

--- a/pdfstitcher.py
+++ b/pdfstitcher.py
@@ -708,7 +708,7 @@ class SewGUI(wx.Frame):
 
             # create the processing objects
             self.layer_filter = LayerFilter(self.in_doc)
-            self.lt.load_new(self.layer_filter.get_layer_names())
+            self.lt.load_new(self.layer_filter.get_layer_names(self.layer_filter.pdf))
 
             self.tiler = PageTiler()
             


### PR DESCRIPTION
Changes:
- deduplicate with recursion and depth limit
- work around #89
- check whether the `'/D'` key is present in `OCProperties` (I think I once came across a document that didn't have it)
- transform `get_layer_names()` into a staticmethod for improved reusability