### PR TITLE
Use tuples for (operands,operator) pairs

### DIFF
--- a/layerfilter.py
+++ b/layerfilter.py
@@ -13,7 +13,7 @@ import copy
 #from os import write
 #import sys
 #import utils
-        
+
 STATE_OPS = [k for k,v in pdf_ops.ops.items() if v[0] == 'state']
 STATE_OPS += [k for k,v in pdf_ops.ops.items() if v[0] in ['begin','end'] and v[1] != 'image']
 STROKE_OPS = [k for k,v in pdf_ops.ops.items() if v[0] == 'show' and v[1] == 'stroke'] 
@@ -124,7 +124,6 @@ class LayerFilter:
         
         self.off_ocs = []
         
-        # open a new copy of the input
         output = pikepdf.Pdf.open(self.pdf.filename)
         self.colour_type = None
 
@@ -207,7 +206,7 @@ class LayerFilter:
     def append_layer_properties(self,commands):
         for op,operands in self.clean_line_props[self.current_layer_name].items():
             if self.current_state[-1][op] != operands:
-                commands.append([operands,pikepdf.Operator(op)])
+                commands.append( (operands,pikepdf.Operator(op)) )
                 self.current_state[-1][op] = operands
     
     def initialize_state(self):
@@ -233,7 +232,7 @@ class LayerFilter:
     def restore_state(self,commands):
         self.remove_q_state()
         for op, operands in self.current_state[-1].items():
-            commands.append([operands,pikepdf.Operator(op)])
+            commands.append( (operands,pikepdf.Operator(op)) )
 
     def filter_stream(self,ob,page_props,oc_forms,in_oc):
         previous_operator = ''
@@ -265,7 +264,7 @@ class LayerFilter:
                         'layer': oc_forms[ob_name]['layer'],
                         'state': copy.copy(self.current_state)
                     }
-                    commands.append([operands,operator])
+                    commands.append( (operands,operator) )
                     previous_operator = op
                     continue
 
@@ -295,7 +294,7 @@ class LayerFilter:
                     elif op == 'Q':
                         self.remove_q_state()
                     
-                    commands.append([operands,operator])
+                    commands.append( (operands,operator) )
                     previous_operator = op
 
             if op == 'EMC':

--- a/layerfilter.py
+++ b/layerfilter.py
@@ -124,6 +124,7 @@ class LayerFilter:
         
         self.off_ocs = []
         
+        # open a new copy of the input
         output = pikepdf.Pdf.open(self.pdf.filename)
         self.colour_type = None
 


### PR DESCRIPTION
to ensure correct behaviour with pikepdf 2.16.0
cf. https://github.com/pikepdf/pikepdf/issues/229