### PR TITLE
Do not setup locale in PageTiler

### DIFF
--- a/tile_pages.py
+++ b/tile_pages.py
@@ -47,8 +47,6 @@ class PageTiler:
             center_content = None,
         ):
         
-        utils.setup_locale()
-        
         self.in_doc = in_doc
         
         if isinstance(page_range, str):


### PR DESCRIPTION
I moved the call to an `__init__` file