### PR TITLE
Setup locale in PageTiler command-line tool

### DIFF
--- a/tile_pages.py
+++ b/tile_pages.py
@@ -646,6 +646,7 @@ def parse_arguments():
 
 
 if __name__ == "__main__":
-
+    
+    utils.setup_locale()
     args = parse_arguments()
     new_doc, success = main(args)


### PR DESCRIPTION
Otherwise it complains about _ being undefined. I missed that in my previous PR.