### PR TITLE
Add flathub badge for downloading PDFStitcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For up-to-date information, also check out https://www.pdfstitcher.org.
 ## Download the latest release
 * [Windows (7 or 10, 64-bit)](https://github.com/cfcurtis/pdfstitcher/releases/latest/download/pdfstitcher.exe)
 * [macOS (High Sierra or higher)](https://github.com/cfcurtis/pdfstitcher/releases/latest/download/PDFStitcher-Installer.dmg)
+* <a href='https://flathub.org/apps/details/com.github.cfcurtis.pdfstitcher'><img width='120' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.svg'/></a>
 
 **Translations:**
 PDFStitcher will detect system language settings and change localisation if supported. 


### PR DESCRIPTION
Add a badge image to link to PDFStitcher flathub page.