### PR TITLE
Modify line properties for documents without layers

### DIFF
--- a/pdfstitcher/gui/io_tab.py
+++ b/pdfstitcher/gui/io_tab.py
@@ -21,6 +21,7 @@ class IOTab(scrolled.ScrolledPanel):
     def __init__(self, parent, main_gui):
         super(IOTab, self).__init__(parent)
 
+        self.main_gui = main_gui
         vert_sizer = wx.BoxSizer(wx.VERTICAL)
 
         # add the various parameter inputs
@@ -150,7 +151,6 @@ class IOTab(scrolled.ScrolledPanel):
             flag=wx.TOP | wx.LEFT | wx.RIGHT,
             border=self.FromDIP(utils.BORDER * 2),
         )
-        self.on_option_checked(event=None)
 
         self.SetSizer(vert_sizer)
         self.SetupScrolling()
@@ -180,3 +180,6 @@ class IOTab(scrolled.ScrolledPanel):
                 + "\n"
                 + _("Optionally, add margins to each page")
             )
+
+        self.main_gui.tt.Enable(do_tile)
+        self.main_gui.lt.Enable(do_layers)

--- a/pdfstitcher/gui/layers_tab.py
+++ b/pdfstitcher/gui/layers_tab.py
@@ -322,7 +322,7 @@ class LayersTab(scrolled.ScrolledPanel):
         self.reset_ls_btn.SetLabel(_("Reset") + " " + event.Label)
 
     def load_new(self, layers):
-        maybe_spacer = self.layer_pane.GetSizer().GetItem(0)
+        maybe_spacer = self.line_prop_pane.GetSizer().GetItem(0)
         if not layers:
             self.status_txt.SetLabel(
                 _("No layers found in input document.")
@@ -331,7 +331,7 @@ class LayersTab(scrolled.ScrolledPanel):
             )
             self.layer_splitter.Unsplit(self.layer_pane)
             if maybe_spacer.IsSpacer():
-                self.layer_pane.GetSizer().Remove(0)
+                self.line_prop_pane.GetSizer().Remove(0)
             self.apply_reset_pane.Hide()
             self.Layout()
             return False
@@ -347,7 +347,7 @@ class LayersTab(scrolled.ScrolledPanel):
         self.status_txt.SetLabel(_("Select layers to include in output document."))
         self.layer_splitter.SplitVertically(self.layer_pane, self.line_prop_pane)
         if not maybe_spacer.IsSpacer():
-            self.layer_pane.GetSizer().InsertSpacer(0, 100)
+            self.line_prop_pane.GetSizer().InsertSpacer(0, 100)
         self.apply_reset_pane.Show()
         self.Layout()
 

--- a/pdfstitcher/gui/layers_tab.py
+++ b/pdfstitcher/gui/layers_tab.py
@@ -33,13 +33,13 @@ class LayersTab(scrolled.ScrolledPanel):
 
         # the main splitter for the layer stuff
         self.layer_splitter = wx.SplitterWindow(self, style=wx.SP_LIVE_UPDATE)
-        layer_pane = wx.Panel(self.layer_splitter)
+        self.layer_pane = wx.Panel(self.layer_splitter)
         layer_sizer = wx.BoxSizer(wx.VERTICAL)
-        layer_pane.SetSizer(layer_sizer)
+        self.layer_pane.SetSizer(layer_sizer)
 
         # delete or hide deselected layers
         self.delete_ocgs = wx.RadioBox(
-            layer_pane, label=_("Deselected layers:"), choices=[_("Delete"), _("Hide")]
+            self.layer_pane, label=_("Deselected layers:"), choices=[_("Delete"), _("Hide")]
         )
         layer_sizer.Add(
             self.delete_ocgs,
@@ -48,7 +48,7 @@ class LayersTab(scrolled.ScrolledPanel):
         )
 
         # check all, background, etc
-        self.include_nonoc = wx.CheckBox(layer_pane, label=_("Include non-optional content"))
+        self.include_nonoc = wx.CheckBox(self.layer_pane, label=_("Include non-optional content"))
         self.include_nonoc.SetValue(1)
         layer_sizer.Add(
             self.include_nonoc,
@@ -56,7 +56,7 @@ class LayersTab(scrolled.ScrolledPanel):
             border=self.FromDIP(utils.BORDER),
         )
 
-        self.select_all = wx.CheckBox(layer_pane, label=_("Deselect all"))
+        self.select_all = wx.CheckBox(self.layer_pane, label=_("Deselect all"))
         self.select_all.Bind(wx.EVT_CHECKBOX, self.on_select_all)
         layer_sizer.Add(
             self.select_all,
@@ -65,7 +65,7 @@ class LayersTab(scrolled.ScrolledPanel):
         )
 
         # the main list box for layers
-        self.layer_list = wx.ListCtrl(layer_pane, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
+        self.layer_list = wx.ListCtrl(self.layer_pane, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
         self.layer_list.EnableCheckBoxes(True)
         self.layer_list.InsertColumn(0, _("Layer Name"))
         self.layer_list.InsertColumn(1, _("Line Properties"))
@@ -79,19 +79,19 @@ class LayersTab(scrolled.ScrolledPanel):
         )
         self.layer_list.Bind(wx.EVT_LIST_ITEM_SELECTED, self.on_layer_selected)
 
-        # build the set of controls for layer options
-        layer_opt_pane = wx.Panel(self.layer_splitter)
-        layer_opt_sizer = wx.BoxSizer(wx.VERTICAL)
-        layer_opt_pane.SetSizer(layer_opt_sizer)
+        # build the set of controls for line properties
+        self.line_prop_pane = wx.Panel(self.layer_splitter)
+        line_prop_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.line_prop_pane.SetSizer(line_prop_sizer)
 
         # line properties
         # colour
-        layer_opt_sizer.AddSpacer(100)
-        layer_opt_sizer.Add(
-            wx.StaticText(layer_opt_pane, label=_("Select line properties to modify"))
+        line_prop_sizer.AddSpacer(100)
+        line_prop_sizer.Add(
+            wx.StaticText(self.line_prop_pane, label=_("Select line properties to modify"))
         )
         newline = wx.BoxSizer(wx.HORIZONTAL)
-        self.enable_colour = wx.CheckBox(layer_opt_pane, label=_("Line Colour") + ":")
+        self.enable_colour = wx.CheckBox(self.line_prop_pane, label=_("Line Colour") + ":")
         self.enable_colour.SetValue(Config.line_props["colour"]["enable"])
         newline.Add(
             self.enable_colour,
@@ -99,26 +99,26 @@ class LayersTab(scrolled.ScrolledPanel):
             border=self.FromDIP(utils.BORDER * 2),
         )
         self.line_colour_ctrl = wx.ColourPickerCtrl(
-            layer_opt_pane, colour=Config.line_props["colour"]["value"]
+            self.line_prop_pane, colour=Config.line_props["colour"]["value"]
         )
         newline.Add(
             self.line_colour_ctrl,
             flag=wx.LEFT | wx.ALIGN_CENTER_VERTICAL,
             border=self.FromDIP(utils.BORDER),
         )
-        layer_opt_sizer.Add(newline, flag=wx.TOP, border=self.FromDIP(utils.BORDER * 2))
+        line_prop_sizer.Add(newline, flag=wx.TOP, border=self.FromDIP(utils.BORDER * 2))
 
         # Fill colour
-        self.do_fill_colour = wx.CheckBox(layer_opt_pane, label=_("Also modify fill colour"))
+        self.do_fill_colour = wx.CheckBox(self.line_prop_pane, label=_("Also modify fill colour"))
         self.do_fill_colour.SetValue(Config.line_props["colour"]["fill"])
-        layer_opt_sizer.AddSpacer(self.FromDIP(utils.BORDER * 2))
-        layer_opt_sizer.Add(
+        line_prop_sizer.AddSpacer(self.FromDIP(utils.BORDER * 2))
+        line_prop_sizer.Add(
             self.do_fill_colour, flag=wx.LEFT, border=self.FromDIP(utils.BORDER * 5)
         )
 
         # thickness
         newline = wx.BoxSizer(wx.HORIZONTAL)
-        self.enable_thickness = wx.CheckBox(layer_opt_pane, label=_("Line Thickness") + ":")
+        self.enable_thickness = wx.CheckBox(self.line_prop_pane, label=_("Line Thickness") + ":")
         self.enable_thickness.SetValue(Config.line_props["thickness"]["enable"])
         newline.Add(
             self.enable_thickness,
@@ -126,7 +126,7 @@ class LayersTab(scrolled.ScrolledPanel):
             border=self.FromDIP(utils.BORDER * 2),
         )
         self.line_thick_ctrl = wx.TextCtrl(
-            layer_opt_pane,
+            self.line_prop_pane,
             size=self.FromDIP(utils.NUM_ENTRY_SIZE),
             value=Config.line_props["thickness"]["value"],
         )
@@ -139,7 +139,7 @@ class LayersTab(scrolled.ScrolledPanel):
         # Extra note for pybabel to make translations make sense (particularly for inches)
         # translation_note: pt = "points", in = "inches", cm = "centimeters"
         unit_choice = [_("in"), _("cm"), _("pt")]
-        self.line_thick_units = wx.ComboBox(layer_opt_pane, choices=unit_choice)
+        self.line_thick_units = wx.ComboBox(self.line_prop_pane, choices=unit_choice)
         self.line_thick_units.SetSelection(Config.line_props["thickness"]["units"])
 
         newline.Add(
@@ -147,11 +147,11 @@ class LayersTab(scrolled.ScrolledPanel):
             flag=wx.LEFT | wx.ALIGN_CENTER_VERTICAL,
             border=self.FromDIP(utils.BORDER),
         )
-        layer_opt_sizer.Add(newline, flag=wx.TOP, border=self.FromDIP(utils.BORDER * 2))
+        line_prop_sizer.Add(newline, flag=wx.TOP, border=self.FromDIP(utils.BORDER * 2))
 
         # style
         newline = wx.BoxSizer(wx.HORIZONTAL)
-        self.enable_style = wx.CheckBox(layer_opt_pane, label=_("Line Style") + ":")
+        self.enable_style = wx.CheckBox(self.line_prop_pane, label=_("Line Style") + ":")
         self.enable_style.SetValue(Config.line_props["style"]["enable"])
         newline.Add(
             self.enable_style,
@@ -160,7 +160,7 @@ class LayersTab(scrolled.ScrolledPanel):
         )
         self.style_names = (_("Solid"), _("Dashed"), _("Dotted"))
         self.line_style_ctrl = wx.ComboBox(
-            layer_opt_pane,
+            self.line_prop_pane,
             choices=self.style_names,
             style=wx.CB_READONLY,
         )
@@ -170,13 +170,15 @@ class LayersTab(scrolled.ScrolledPanel):
             flag=wx.LEFT | wx.ALIGN_CENTER_VERTICAL,
             border=self.FromDIP(utils.BORDER),
         )
-        layer_opt_sizer.Add(newline, flag=wx.TOP, border=self.FromDIP(utils.BORDER * 2))
+        line_prop_sizer.Add(newline, flag=wx.TOP, border=self.FromDIP(utils.BORDER * 2))
 
         # apply/reset buttons
+        self.apply_reset_pane = wx.Panel(self.line_prop_pane)
+        apply_sizer = wx.BoxSizer(wx.VERTICAL)
         newline = wx.BoxSizer(wx.HORIZONTAL)
-        self.apply_ls_btn = wx.Button(layer_opt_pane, label=_("Apply"))
+        self.apply_ls_btn = wx.Button(self.apply_reset_pane, label=_("Apply"))
         self.apply_ls_btn.Bind(wx.EVT_BUTTON, self.apply_ls_pressed)
-        self.reset_ls_btn = wx.Button(layer_opt_pane, label=_("Reset"))
+        self.reset_ls_btn = wx.Button(self.apply_reset_pane, label=_("Reset"))
         self.reset_ls_btn.Bind(wx.EVT_BUTTON, self.reset_ls_pressed)
         newline.Add(
             self.apply_ls_btn,
@@ -190,30 +192,31 @@ class LayersTab(scrolled.ScrolledPanel):
             flag=wx.EXPAND | wx.LEFT,
             border=self.FromDIP(utils.BORDER),
         )
-        layer_opt_sizer.Add(newline, flag=wx.TOP | wx.EXPAND, border=self.FromDIP(utils.BORDER * 2))
+        apply_sizer.Add(newline, flag=wx.TOP | wx.EXPAND, border=self.FromDIP(utils.BORDER * 2))
 
         # apply to checked
         newline = wx.BoxSizer(wx.HORIZONTAL)
-        self.apply_ls_all = wx.Button(layer_opt_pane, label=_("Apply to checked"))
+        self.apply_ls_all = wx.Button(self.apply_reset_pane, label=_("Apply to checked"))
         self.apply_ls_all.Bind(wx.EVT_BUTTON, self.apply_all_pressed)
-        self.reset_all = wx.Button(layer_opt_pane, label=_("Reset checked"))
+        self.reset_all = wx.Button(self.apply_reset_pane, label=_("Reset checked"))
         self.reset_all.Bind(wx.EVT_BUTTON, self.reset_all_pressed)
         newline.Add(self.apply_ls_all, flag=wx.LEFT, border=self.FromDIP(utils.BORDER))
         newline.Add(self.reset_all, flag=wx.LEFT, border=self.FromDIP(utils.BORDER))
-        layer_opt_sizer.Add(newline, flag=wx.TOP, border=self.FromDIP(utils.BORDER))
+        apply_sizer.Add(newline, flag=wx.TOP, border=self.FromDIP(utils.BORDER))
+        self.apply_reset_pane.SetSizer(apply_sizer)
+        line_prop_sizer.Add(
+            self.apply_reset_pane, flag=wx.TOP, border=self.FromDIP(utils.BORDER * 2)
+        )
 
         # Final assembly
-        self.layer_splitter.SplitVertically(layer_pane, layer_opt_pane)
         self.layer_splitter.SetSashGravity(0.5)
+        self.layer_splitter.SplitVertically(self.layer_pane, self.line_prop_pane)
         vert_sizer.Add(
             self.layer_splitter,
             proportion=1,
             flag=wx.TOP | wx.LEFT | wx.RIGHT | wx.EXPAND,
             border=self.FromDIP(utils.BORDER * 2),
         )
-
-        # hide controls until a PDF with layers is loaded
-        self.layer_splitter.Hide()
 
         self.SetSizer(vert_sizer)
         self.SetupScrolling()
@@ -312,8 +315,10 @@ class LayersTab(scrolled.ScrolledPanel):
 
     def load_new(self, layers):
         if not layers:
-            self.layer_splitter.Hide()
             self.status_txt.SetLabel(_("No layers found in input document."))
+            self.layer_splitter.Unsplit(self.layer_pane)
+            self.apply_reset_pane.Hide()
+            self.Layout()
             return False
 
         self.layer_list.DeleteAllItems()
@@ -325,7 +330,8 @@ class LayersTab(scrolled.ScrolledPanel):
         self.set_all_checked(True)
 
         self.status_txt.SetLabel(_("Select layers to include in output document."))
-        self.layer_splitter.Show()
+        self.layer_splitter.SplitVertically(self.layer_pane, self.line_prop_pane)
+        self.apply_reset_pane.Show()
         self.Layout()
 
         # reset the line properties dictionary

--- a/pdfstitcher/gui/main_frame.py
+++ b/pdfstitcher/gui/main_frame.py
@@ -415,13 +415,7 @@ class PDFStitcherFrame(wx.Frame):
                 self.io.do_tile.SetValue(1)
 
         # update the layer options
-        self.lt.load_new(self.main_process.doc_info["layers"])
-        if self.main_process.doc_info["layers"]:
-            self.io.do_layers.SetValue(1)
-            self.io.do_layers.Enable()
-        else:
-            self.io.do_layers.SetValue(0)
-            self.io.do_layers.Disable()
+        self.io.do_layers.SetValue(self.lt.load_new(self.main_process.doc_info["layers"]))
 
         # update the processing description
         self.io.on_option_checked(None)

--- a/pdfstitcher/gui/main_frame.py
+++ b/pdfstitcher/gui/main_frame.py
@@ -404,10 +404,8 @@ class PDFStitcherFrame(wx.Frame):
         if self.main_process.doc_info["n_pages"] == 1:
             self.io.do_tile.SetValue(0)
             self.io.do_tile.Disable()
-            self.tt.Disable()
         else:
             self.io.do_tile.Enable()
-            self.tt.Enable()
 
             # check how big the pages are, and default to no tiling if they're over A3
             w, h = self.main_process.doc_info["first_page_dims"]
@@ -421,11 +419,9 @@ class PDFStitcherFrame(wx.Frame):
         if self.main_process.doc_info["layers"]:
             self.io.do_layers.SetValue(1)
             self.io.do_layers.Enable()
-            self.lt.Enable()
         else:
             self.io.do_layers.SetValue(0)
             self.io.do_layers.Disable()
-            self.lt.Disable()
 
         # update the processing description
         self.io.on_option_checked(None)

--- a/pdfstitcher/gui/main_frame.py
+++ b/pdfstitcher/gui/main_frame.py
@@ -154,12 +154,23 @@ class PDFStitcherFrame(wx.Frame):
         """
         Helper function to pack up the layer options
         """
-        return {
-            "keep_ocs": self.lt.get_selected_layers(),
-            "line_props": self.lt.line_props,
-            "keep_non_oc": bool(self.lt.include_nonoc.GetValue()),
-            "delete_ocgs": bool(self.lt.delete_ocgs.GetSelection() == 0),
-        }
+        # no layers in document
+        if not self.main_process.doc_info["layers"]:
+            layer_opts = {
+                "keep_ocs": "no_ocgs",
+                "line_props": self.lt.line_props,
+                "keep_non_oc": True,
+                "delete_ocgs": True,
+            }
+        else:
+            layer_opts = {
+                "keep_ocs": self.lt.get_selected_layers(),
+                "line_props": self.lt.line_props,
+                "keep_non_oc": bool(self.lt.include_nonoc.GetValue()),
+                "delete_ocgs": bool(self.lt.delete_ocgs.GetSelection() == 0),
+            }
+
+        return layer_opts
 
     def on_go_pressed(self, event):
         if self.main_process.in_doc is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pdfstitcher"
 version = "1.0b2"
 description = "The open source PDF stitching software for sewists, by sewists."
 readme = "README.md"
-requires-python = ">=3.8, <=3.12"
+requires-python = ">=3.8, <3.13"
 license = {file = "LICENSE"}
 keywords = ["pdf", "sewing", "utility", "stitch", "n-up", "page imposition"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdfstitcher"
-version = "1.0b2"
+version = "1.0b3"
 description = "The open source PDF stitching software for sewists, by sewists."
 readme = "README.md"
 requires-python = ">=3.8, <3.13"


### PR DESCRIPTION
This has been a fairly common request, and relatively straightforward to implement (mainly UI trickiness). It's still not going to give great results in many cases as it will apply blanket line property modifications to all lines, but it seems to be behaving for cases where people just want to make lines a bit thicker (for example).

In doing this, a couple of small (and likely very old) things were changed:
- Swapped the order of CMYK and RGB, as the colours can look subtly different and RGB is more common (so coming second makes it take priority)
- If a "G/g" command is issued, the entire colourspace is set to greyscale and RGB mods are ignored. I'm now replacing all Gs with the selected line colour.