### PR TITLE
Bump to v1.0.1

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.8 # old to support Windows 7
-        
+      
       - name: Update package index
         run: sudo apt-get update
       - name: Install wxPython dependencies
@@ -61,6 +61,10 @@ jobs:
           libwebkit2gtk-4.0-dev \
           libxtst-dev
       
+      - name: Copy resources directory
+        # PyPi needs to have resources in the same directory as the package
+        run: cp -r resources pdfstitcher/resources
+  
       - name: Compile translation files and build distribution
         run: |
           python3 build/update_loc.py --compile

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-recursive-include resources *.ico
-recursive-include resources *.mo
-recursive-include resources *.po
+recursive-include pdfstitcher/resources *.ico
+recursive-include pdfstitcher/resources *.mo
+recursive-include pdfstitcher/resources *.po

--- a/pdfstitcher/gui/main_frame.py
+++ b/pdfstitcher/gui/main_frame.py
@@ -74,7 +74,9 @@ class PDFStitcherFrame(wx.Frame):
         self.Bind(wx.EVT_CLOSE, self.on_exit)
 
         if sys.platform == "win32" or sys.platform == "linux":
-            self.SetIcon(wx.Icon(utils.resource_path("stitcher-icon.ico")))
+            ico = utils.resource_path("stitcher-icon.ico")
+            if ico.exists():
+                self.SetIcon(wx.Icon(str(ico)))
 
         if len(sys.argv) > 1:
             self.load_file(sys.argv[1])
@@ -310,8 +312,10 @@ class PDFStitcherFrame(wx.Frame):
         """
         Show the about info.
         """
+        ico = utils.resource_path("stitcher-icon.ico")
         about_info = wx.adv.AboutDialogInfo()
-        about_info.SetIcon(wx.Icon(utils.resource_path("stitcher-icon.ico")))
+        if ico.exists():
+            about_info.SetIcon(wx.Icon(str(ico)))
         about_info.SetName("PDFStitcher")
         about_info.SetVersion(utils.VERSION_STRING)
         about_info.SetDescription(_("The PDF Stitching app for sewists, by sewists."))

--- a/pdfstitcher/utils.py
+++ b/pdfstitcher/utils.py
@@ -162,21 +162,28 @@ def resource_path(relative_path: str) -> Path:
         # PyInstaller creates a temp folder and stores path in _MEIPASS
         base_path = Path(sys._MEIPASS) / "resources"
     else:
-        # Nuitka places resources adjacent to the executable
+        # Nuitka and PyPi place resources adjacent to the executable
         base_path = Path(__file__).parent.absolute() / "resources"
 
     # If we're running from source, the resources are in the parent directory
     if not base_path.exists():
         base_path = Path(__file__).parent.parent.absolute() / "resources"
 
-    return str(base_path / relative_path)
+    return base_path / relative_path
 
 
 def get_valid_langs() -> list:
     """
     Get a list of valid languages for the UI.
     """
-    return ["en"] + [f.name for f in os.scandir(resource_path("locale")) if f.is_dir()]
+    valid = ["en"]
+    try:
+        valid += [f.name for f in os.scandir(resource_path("locale")) if f.is_dir()]
+    except FileNotFoundError:
+        # Something weird with resources, but don't crash
+        pass
+
+    return valid
 
 
 def setup_locale(lang: str = None) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdfstitcher"
-version = "1.0.0"
+version = "1.0.1"
 description = "The open source PDF stitching software for sewists, by sewists."
 readme = "README.md"
 requires-python = ">=3.8, <3.13"


### PR DESCRIPTION
PyPi needs resources in package, so copying before running PyPi build.

Also making it not crash entirely if resources not found (just translations + icons).