### PR TITLE
Add per-page rotation support

### DIFF
--- a/pdfstitcher/cli/app.py
+++ b/pdfstitcher/cli/app.py
@@ -67,7 +67,7 @@ def add_tile_args(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=0,
         choices=[0, 90, 180, 270],
-        help=_("Rotate pages"),
+        help=_("Rotate all pages (overridden by per-page rotation in -p/--pages)"),
     )
     t_parser.add_argument(
         "--col-major",
@@ -172,7 +172,8 @@ def parse_arguments() -> argparse.Namespace:
         "-p",
         "--pages",
         help=_(
-            "Pages to Process. May be range or list (e.g. 1-5 or 1,3,5-7, etc). "
+            "Pages to Process. May be range or list (e.g. 1-5 or 1,3,5-7, etc) with optional rotation "
+            "(e.g. 1-3,4r90,5-7r180 rotates page 4 by 90° and pages 5-7 by 180°). "
             "Default: entire document. Use 0 values to add blank pages."
         ),
     )

--- a/pdfstitcher/gui/io_tab.py
+++ b/pdfstitcher/gui/io_tab.py
@@ -98,6 +98,8 @@ class IOTab(scrolled.ScrolledPanel):
                     _("Pages assemble in specified order. 0 inserts a blank page.")
                     + "\n"
                     + _("Use - for ranges. Example: 1-3, 0, 4, 0, 5-10.")
+                    + "\n"
+                    + _("Add r and degrees to rotate pages. Example: 1-3, 4r90, 5-7r180.")
                 ),
             ),
             flag=wx.TOP | wx.LEFT | wx.RIGHT,

--- a/pdfstitcher/processing/layerfilter.py
+++ b/pdfstitcher/processing/layerfilter.py
@@ -96,6 +96,10 @@ class LayerFilter(ProcessingBase):
             # no OCGs in document, and hopefully nobody names a layer this
             return
 
+        # Check if OCProperties exists and has OCGs
+        if "/OCProperties" not in self.out_doc.Root.keys() or "/OCGs" not in self.out_doc.Root.OCProperties.keys():
+            return
+
         # edit the OCG listing in the root
         On = [
             oc for oc in self.out_doc.Root.OCProperties.OCGs if str(oc.Name) in self.p["keep_ocs"]

--- a/pdfstitcher/processing/pagefilter.py
+++ b/pdfstitcher/processing/pagefilter.py
@@ -19,21 +19,27 @@ class PageFilter(ProcessingBase):
     def run(self, **kwargs) -> None:
         """
         The main method to run the filter. This one just filters to a selected page range
-        with an optional margin added to each.
+        with an optional margin added to each and applies per-page rotation if specified.
         """
         # copy the selected pages to a new document
         self.out_doc = utils.init_new_doc(self.in_doc)
 
-        for p in self.page_range:
+        for page_info in self.page_range_with_rotation:
+            p = page_info["page"]
+            rotation = page_info["rotation"]
             user_unit = 1
+            
             if p == 0:
                 mbox = self.in_doc.pages[-1].MediaBox
                 self.out_doc.add_blank_page(page_size=(mbox[2], mbox[3]))
             else:
                 self.out_doc.pages.extend([self.in_doc.pages[p - 1]])
+                if "/UserUnit" in self.in_doc.pages[p - 1].keys():
+                    user_unit = float(self.in_doc.pages[p - 1].UserUnit)
 
-            if "/UserUnit" in self.in_doc.pages[p - 1].keys():
-                user_unit = float(self.in_doc.pages[p - 1].UserUnit)
+            # Apply rotation if specified
+            if rotation != 0:
+                self._apply_rotation_to_page(self.out_doc.pages[-1], rotation, user_unit)
 
             if self.p["margin"]:
                 # if margins were added, expand the new page boxes
@@ -54,3 +60,52 @@ class PageFilter(ProcessingBase):
                 self.out_doc.pages[-1].CropBox = media_box
 
         return self.out_doc
+
+    def _apply_rotation_to_page(self, page: pikepdf.Page, rotation_degrees: int, user_unit: float) -> None:
+        """
+        Apply rotation to a page by converting it to XObject and applying transformation matrix.
+        """
+        # Convert degrees to SW_ROTATION enum
+        sw_rotation = utils.degrees_to_sw_rotation(rotation_degrees)
+        
+        # Get rotation matrix
+        rotation_matrix = utils.get_rotation_matrix(sw_rotation)
+        
+        # Get page dimensions
+        media_box = page.MediaBox
+        width = float(media_box[2] - media_box[0])
+        height = float(media_box[3] - media_box[1])
+        
+        # Calculate new dimensions after rotation
+        new_width, new_height = utils.apply_rotation_to_dimensions(width, height, sw_rotation)
+        
+        # Convert page to XObject
+        xobj = page.as_form_xobject()
+        
+        # Calculate translation based on rotation
+        from pdfstitcher.processing.pagetiler import SW_ROTATION
+        if sw_rotation == SW_ROTATION.CLOCKWISE:
+            tx, ty = new_width, 0
+        elif sw_rotation == SW_ROTATION.COUNTERCLOCKWISE:
+            tx, ty = 0, new_height
+        elif sw_rotation == SW_ROTATION.TURNAROUND:
+            tx, ty = new_width, new_height
+        else:
+            tx, ty = 0, 0
+        
+        # Create transformation matrix (rotation + translation)
+        cm_matrix = rotation_matrix + [tx, ty]
+        
+        # Create new page content with transformation
+        cm_op = pikepdf.Stream(page._f, b" ".join([str(val).encode() for val in cm_matrix]) + b" cm")
+        do_op = pikepdf.Stream(page._f, b"/Page Do")
+        q_op = pikepdf.Stream(page._f, b"q")
+        Q_op = pikepdf.Stream(page._f, b"Q")
+        
+        # Replace page content
+        page.Contents = pikepdf.Array([q_op, cm_op, do_op, Q_op])
+        page.Resources["/XObject"] = pikepdf.Dictionary({"/Page": xobj})
+        
+        # Update MediaBox and CropBox with new dimensions
+        page.MediaBox = [0, 0, new_width, new_height]
+        page.CropBox = [0, 0, new_width, new_height]

--- a/pdfstitcher/processing/procbase.py
+++ b/pdfstitcher/processing/procbase.py
@@ -74,17 +74,40 @@ class ProcessingBase(ABC):
 
     @property
     def page_range(self) -> list:
-        return self._page_range
+        """Returns list of page numbers for backward compatibility"""
+        if self._page_range is None:
+            return None
+        return [p["page"] if isinstance(p, dict) else p for p in self._page_range]
+
+    @property
+    def page_range_with_rotation(self) -> list:
+        """Returns full page range with rotation info"""
+        if self._page_range is None:
+            return None
+        # Ensure all entries are in dict format
+        result = []
+        for p in self._page_range:
+            if isinstance(p, dict):
+                result.append(p)
+            else:
+                result.append({"page": p, "rotation": 0})
+        return result
 
     @page_range.setter
     def page_range(self, pr: Union[str, list]) -> None:
-        if isinstance(pr, list):
-            parsed_range = pr
-        elif isinstance(pr, str):
-            parsed_range = utils.parse_page_range(pr)
+        if isinstance(pr, str):
+            # Use the new parser that supports rotation
+            parsed_range = utils.parse_page_range_with_rotation(pr)
+        elif isinstance(pr, list):
+            # Handle both old format (list of ints) and new format (list of dicts)
+            if pr and all(isinstance(p, int) for p in pr):
+                # Convert old format to new format
+                parsed_range = [{"page": p, "rotation": 0} for p in pr]
+            else:
+                parsed_range = pr
         elif self.page_range is None and self.in_doc is not None:
             print(_("No page range specified, defaulting to all"))
-            parsed_range = list(range(1, len(self.in_doc.pages) + 1))
+            parsed_range = [{"page": p, "rotation": 0} for p in range(1, len(self.in_doc.pages) + 1)]
         else:
             parsed_range = []
 
@@ -102,18 +125,22 @@ class ProcessingBase(ABC):
         Compares the page range to the number of pages in the document.
         If any pages are out of range, removes them and warns the user.
         """
-        if not self.page_range or not self.in_doc:
+        if not self._page_range or not self.in_doc:
             return
 
         n_pages = len(self.in_doc.pages)
-        no_good = set()
-        for p in self._page_range:
-            if p < 0 or p > n_pages:
-                no_good.add(p)
-
-        for p in no_good:
-            print(_("Page {} is out of range. Removing from page list.".format(p)))
-            self._page_range.remove(p)
+        no_good = []
+        
+        for i, p in enumerate(self._page_range):
+            # Handle both dict and int formats
+            page_num = p["page"] if isinstance(p, dict) else p
+            if page_num < 0 or page_num > n_pages:
+                no_good.append(i)
+                print(_("Page {} is out of range. Removing from page list.".format(page_num)))
+        
+        # Remove invalid pages in reverse order to maintain indices
+        for i in reversed(no_good):
+            self._page_range.pop(i)
 
     def _warn(self, message: str) -> None:
         """

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -1,0 +1,163 @@
+import pytest
+from pdfstitcher import utils
+from pdfstitcher.processing.pagetiler import SW_ROTATION
+from pdfstitcher.processing.pagefilter import PageFilter
+from pdfstitcher.processing.procbase import ProcessingBase
+
+
+class TestPageRangeRotation:
+    """Test parse_page_range_with_rotation function"""
+    
+    def test_simple_page_range(self):
+        """Test simple page range without rotation"""
+        result = utils.parse_page_range_with_rotation("1,2,3")
+        expected = [
+            {"page": 1, "rotation": 0},
+            {"page": 2, "rotation": 0},
+            {"page": 3, "rotation": 0}
+        ]
+        assert result == expected
+    
+    def test_page_range_with_rotation(self):
+        """Test page range with rotation"""
+        result = utils.parse_page_range_with_rotation("1,2r90,3r180")
+        expected = [
+            {"page": 1, "rotation": 0},
+            {"page": 2, "rotation": 90},
+            {"page": 3, "rotation": 180}
+        ]
+        assert result == expected
+    
+    def test_page_range_with_ranges(self):
+        """Test page range with hyphenated ranges"""
+        result = utils.parse_page_range_with_rotation("1-3,4r90,5-7r180")
+        expected = [
+            {"page": 1, "rotation": 0},
+            {"page": 2, "rotation": 0},
+            {"page": 3, "rotation": 0},
+            {"page": 4, "rotation": 90},
+            {"page": 5, "rotation": 180},
+            {"page": 6, "rotation": 180},
+            {"page": 7, "rotation": 180}
+        ]
+        assert result == expected
+    
+    def test_uppercase_rotation(self):
+        """Test rotation with uppercase R"""
+        result = utils.parse_page_range_with_rotation("1R90,2r180")
+        expected = [
+            {"page": 1, "rotation": 90},
+            {"page": 2, "rotation": 180}
+        ]
+        assert result == expected
+    
+    def test_invalid_rotation(self, capsys):
+        """Test invalid rotation values"""
+        result = utils.parse_page_range_with_rotation("1r45")
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Invalid rotation value: 45" in captured.out
+    
+    def test_invalid_format(self, capsys):
+        """Test invalid page format"""
+        result = utils.parse_page_range_with_rotation("abc")
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Invalid page range format: abc" in captured.out
+    
+    def test_empty_range(self, capsys):
+        """Test empty page range"""
+        result = utils.parse_page_range_with_rotation("")
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Please specify a page range" in captured.out
+    
+    def test_all_rotations(self):
+        """Test all valid rotation values"""
+        result = utils.parse_page_range_with_rotation("1r0,2r90,3r180,4r270")
+        expected = [
+            {"page": 1, "rotation": 0},
+            {"page": 2, "rotation": 90},
+            {"page": 3, "rotation": 180},
+            {"page": 4, "rotation": 270}
+        ]
+        assert result == expected
+
+
+class TestRotationUtilities:
+    """Test rotation utility functions"""
+    
+    def test_degrees_to_sw_rotation(self):
+        """Test converting degrees to SW_ROTATION enum"""
+        assert utils.degrees_to_sw_rotation(0) == SW_ROTATION.NONE
+        assert utils.degrees_to_sw_rotation(90) == SW_ROTATION.CLOCKWISE
+        assert utils.degrees_to_sw_rotation(180) == SW_ROTATION.TURNAROUND
+        assert utils.degrees_to_sw_rotation(270) == SW_ROTATION.COUNTERCLOCKWISE
+    
+    def test_invalid_degrees(self):
+        """Test invalid degree values"""
+        with pytest.raises(ValueError):
+            utils.degrees_to_sw_rotation(45)
+    
+    def test_get_rotation_matrix(self):
+        """Test rotation matrix generation"""
+        assert utils.get_rotation_matrix(SW_ROTATION.NONE) == [1, 0, 0, 1]
+        assert utils.get_rotation_matrix(SW_ROTATION.CLOCKWISE) == [0, -1, 1, 0]
+        assert utils.get_rotation_matrix(SW_ROTATION.COUNTERCLOCKWISE) == [0, 1, -1, 0]
+        assert utils.get_rotation_matrix(SW_ROTATION.TURNAROUND) == [-1, 0, 0, -1]
+    
+    def test_apply_rotation_to_dimensions(self):
+        """Test dimension calculations after rotation"""
+        # No rotation
+        assert utils.apply_rotation_to_dimensions(100, 200, SW_ROTATION.NONE) == (100, 200)
+        assert utils.apply_rotation_to_dimensions(100, 200, SW_ROTATION.TURNAROUND) == (100, 200)
+        
+        # 90/270 degree rotation swaps dimensions
+        assert utils.apply_rotation_to_dimensions(100, 200, SW_ROTATION.CLOCKWISE) == (200, 100)
+        assert utils.apply_rotation_to_dimensions(100, 200, SW_ROTATION.COUNTERCLOCKWISE) == (200, 100)
+
+
+class TestProcessingBaseRotation:
+    """Test ProcessingBase API changes for rotation"""
+    
+    def test_backward_compatibility_list(self, doc_mixed_layers):
+        """Test backward compatibility with list of integers"""
+        proc = PageFilter(doc=doc_mixed_layers)
+        proc.page_range = [1, 2]
+        
+        # Should return list of integers for backward compatibility
+        assert proc.page_range == [1, 2]
+        
+        # Should return full format with rotation
+        expected = [
+            {"page": 1, "rotation": 0},
+            {"page": 2, "rotation": 0}
+        ]
+        assert proc.page_range_with_rotation == expected
+    
+    def test_string_with_rotation(self, doc_mixed_layers):
+        """Test string input with rotation"""
+        proc = PageFilter(doc=doc_mixed_layers)
+        proc.page_range = "1r90,2r180"
+        
+        # Should return list of page numbers
+        assert proc.page_range == [1, 2]
+        
+        # Should return full format with rotation
+        expected = [
+            {"page": 1, "rotation": 90},
+            {"page": 2, "rotation": 180}
+        ]
+        assert proc.page_range_with_rotation == expected
+    
+    def test_page_validation_with_rotation(self, doc_mixed_layers, capsys):
+        """Test page validation with rotation format"""
+        proc = PageFilter(doc=doc_mixed_layers)
+        # doc_mixed_layers has multiple pages
+        proc.page_range = "1r90,2,5r180"
+        
+        # Page 5 should be removed as out of range
+        assert proc.page_range == [1, 2]
+        
+        captured = capsys.readouterr()
+        assert "Page 5 is out of range" in captured.out


### PR DESCRIPTION
Fixes #225.

The below commit message is AI generated, but **this paragraph is not**. See the issue write-up for motivation and the development process the human (me) followed.

--------

Implements per-page rotation feature allowing users to specify rotation for individual pages or ranges using syntax like "1-3,4r90,5-7r180" in the page range field. 

Key changes:
- Added rotation suffix support (r0, r90, r180, r270) to page range parser
- Works in both CLI (-p/--pages) and GUI page range fields
- Per-page rotation overrides global rotation when both are specified
- Maintains full backward compatibility with existing page range syntax

Bug fixes:
- Fixed duplicate page handling in PageTiler where specifying the same page multiple times (e.g. "1,1,1") would only include the first instance. Now uses position-based indexing to create unique keys for each page occurrence.
- Added safety check in LayerFilter to prevent KeyError when OCProperties is missing

The implementation preserves all existing functionality while adding fine-grained control over page rotation, useful for mixed-orientation documents and complex assembly workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)